### PR TITLE
Update MAU_CheckMethod.sh

### DIFF
--- a/MAU_CheckMethod.sh
+++ b/MAU_CheckMethod.sh
@@ -3,9 +3,9 @@
 ## Extension Attribute to report which mode Microsoft AutoUpdate is using
 
 if [ -d /Library/Application\ Support/Microsoft/MAU2.0/Microsoft\ AutoUpdate.app ]; then
-    HowToCheck=`python -c "from Foundation import CFPreferencesCopyAppValue; print CFPreferencesCopyAppValue('HowToCheck', 'com.microsoft.autoupdate2')"`
+	HowToCheck=$(defaults read /Users/rstasel/Library/Preferences/com.microsoft.autoupdate2 HowToCheck 2>/dev/null)
 
-    if [ "$HowToCheck" = "None" ]; then    
+if [ -z "$HowToCheck" ]; then    
         echo "<result>AutomaticDownload (inferred)</result>"
     else
         echo "<result>$HowToCheck</result>"


### PR DESCRIPTION
Removal of Python call. Monterey "safe" (Monterey throws error during EA evaluation that relies on Python.